### PR TITLE
Add support for lines thickness with added sharpness

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If `OUTPUT` is missing, then svg2jxl prints the [JXL Art](https://jxl-art.surma.
 ## Options
 
 ```
--h, --help                                    show this help message and exit
+-h, --help                                    Show this help message and exit
 -s SCALE, --scale SCALE                       Scale for working resolution
 -u UPSAMPLE, --upsample UPSAMPLE              JXL tree Upsample
 -e ERROR, --error ERROR                       Allowed error, multiplied by scale^2
@@ -27,6 +27,7 @@ If `OUTPUT` is missing, then svg2jxl prints the [JXL Art](https://jxl-art.surma.
 -tc THICKNESSC, --thicknessc THICKNESSC       Thickness for colored lines
 -sat SATURATION, --saturation SATURATION      Saturation for black lines
 -satc SATURATIONC, --saturationc SATURATIONC  Saturation for colored lines
+-sh SHARPNESS, --sharpness SHARPNESS          Sharpness for thicker lines, 0 to disable
 -v, --verbose                                 Print more information to stdout
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ pip3 install git+https://github.com/wwww-wwww/spline
 ## Usage
 
 ```
-svg2jxl [OPTIONS] INPUT OUTPUT
+svg2jxl [OPTIONS] INPUT [OUTPUT]
 ```
+
+If `OUTPUT` is missing, then svg2jxl prints the [JXL Art](https://jxl-art.surma.technology) URL to stdout.
 
 ## Options
 
@@ -25,6 +27,7 @@ svg2jxl [OPTIONS] INPUT OUTPUT
 -tc THICKNESSC, --thicknessc THICKNESSC       Thickness for colored lines
 -sat SATURATION, --saturation SATURATION      Saturation for black lines
 -satc SATURATIONC, --saturationc SATURATIONC  Saturation for colored lines
+-v, --verbose                                 Print more information to stdout
 ```
 
 ## Example

--- a/svg2jxl/svg2jxl.py
+++ b/svg2jxl/svg2jxl.py
@@ -105,7 +105,7 @@ def create_spline(points, args, color):
     old_len = len(points)
     points = optimize.optimize(points, args.error * (args.scale**2))
     if args.verbose:
-        print(f"Spline with points: {old_len} -> {len(points)}")
+      print(f"Spline with points: {old_len} -> {len(points)}")
 
   if len(points) < 2:
     return ""
@@ -357,7 +357,10 @@ def main():
     output.write(f"- Set {2 ** args.bitdepth - 1}")
 
     if args.output is None:
-        zcode = base64.b64encode(zlib.compress(output.getvalue().encode(), level=9)[2:-4], altchars=b"-_").decode().replace("=", "")
-        print(f"https://jxl-art.surma.technology/?zcode={zcode}")
+      output_bytes = output.getvalue().encode()
+      output_gzip_bytes = zlib.compress(output_bytes, level=9)
+      output_b64_bytes = base64.b64encode(output_gzip_bytes[2:-4], altchars=b"-_")
+      zcode = output_b64_bytes.decode().replace("=", "")
+      print(f"https://jxl-art.surma.technology/?zcode={zcode}")
   finally:
     output.close()

--- a/svg2jxl/svg2jxl.py
+++ b/svg2jxl/svg2jxl.py
@@ -3,6 +3,9 @@ import math
 import random
 import svgpathtools
 import sys
+import io
+import zlib
+import base64
 import xml.etree.ElementTree
 from svgpathtools import CubicBezier, QuadraticBezier, Arc, Line
 import optimize
@@ -101,7 +104,8 @@ def create_spline(points, args, color):
   if len(points) > 2:
     old_len = len(points)
     points = optimize.optimize(points, args.error * (args.scale**2))
-    print(f"{old_len} -> {len(points)}")
+    if args.verbose:
+        print(f"Spline with points: {old_len} -> {len(points)}")
 
   if len(points) < 2:
     return ""
@@ -146,47 +150,51 @@ def create_spline(points, args, color):
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument("input", help="Input SVG file")
-  parser.add_argument("output", help="Output jxl tree")
+  parser.add_argument("output", help="Output jxl tree", nargs='?')
   parser.add_argument("-s",
                       "--scale",
                       type=float,
                       default=1,
-                      help="Scale for working resolution")
+                      help="Scale for working resolution (default: 1)")
   parser.add_argument("-u",
                       "--upsample",
                       type=int,
                       default=1,
-                      help="JXL tree Upsample")
+                      help="JXL tree upsample (default: 1)")
   parser.add_argument("-e",
                       "--error",
-                      help="Allowed error, multiplied by scale^2",
+                      help="Allowed error, multiplied by scale^2  (default: 1)",
                       type=float,
                       default=1)
   parser.add_argument("-b",
                       "--bitdepth",
                       type=int,
                       default=4,
-                      help="Bitdepth for colors and JXL")
+                      help="Bitdepth for colors and JXL (default: 4)")
   parser.add_argument("-t",
                       "--thickness",
                       type=float,
                       default=0.5,
-                      help="thickness for black lines")
+                      help="thickness for black lines (default: 0.5)")
   parser.add_argument("-tc",
                       "--thicknessc",
                       type=float,
                       default=0.5,
-                      help="thickness for colored lines")
+                      help="thickness for colored lines (default: 0.5)")
   parser.add_argument("-sat",
                       "--saturation",
                       type=float,
                       default=1,
-                      help="saturation for black lines")
+                      help="saturation for black lines (default: 1)")
   parser.add_argument("-satc",
                       "--saturationc",
                       type=float,
                       default=1,
-                      help="saturation for colored lines")
+                      help="saturation for colored lines (default: 1)")
+  parser.add_argument("-v",
+                      "--verbose",
+                      action="store_true",
+                      help="print more information to stdout")
 
   args = parser.parse_args()
 
@@ -223,7 +231,9 @@ def main():
   scale_x = width / viewBox[2]
   scale_y = height / viewBox[3]
 
-  with open(args.output, "w+") as output:
+  output = io.StringIO() if args.output is None else open(args.output, "w+")
+
+  try:
     output.write(header)
     splines = []
 
@@ -331,8 +341,8 @@ def main():
             cubic_points.pop(0)
 
           current_spline.extend(cubic_points)
-        else:
-          print(type(segment))
+        elif args.verbose:
+          print("Ignored segment: " + str(type(segment)))
 
       if current_spline:
         spline = create_spline(current_spline, args, color)
@@ -345,3 +355,9 @@ def main():
             output.flush()
 
     output.write(f"- Set {2 ** args.bitdepth - 1}")
+
+    if args.output is None:
+        zcode = base64.b64encode(zlib.compress(output.getvalue().encode(), level=9)[2:-4], altchars=b"-_").decode().replace("=", "")
+        print(f"https://jxl-art.surma.technology/?zcode={zcode}")
+  finally:
+    output.close()

--- a/svg2jxl/svg2jxl.py
+++ b/svg2jxl/svg2jxl.py
@@ -105,7 +105,7 @@ def create_spline(points, args, color):
     old_len = len(points)
     points = optimize.optimize(points, args.error * (args.scale**2))
     if args.verbose:
-      print(f"Spline with points: {old_len} -> {len(points)}")
+      print(f"Optimized spline points: {old_len} -> {len(points)}")
 
   if len(points) < 2:
     return ""
@@ -150,7 +150,7 @@ def create_spline(points, args, color):
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument("input", help="Input SVG file")
-  parser.add_argument("output", help="Output jxl tree", nargs='?')
+  parser.add_argument("output", help="Output JXL tree", nargs='?')
   parser.add_argument("-s",
                       "--scale",
                       type=float,
@@ -222,11 +222,11 @@ def main():
   height *= args.scale
 
   header = f"""Bitdepth {args.bitdepth}
-  Upsample {args.upsample}
-  Width {round(width)}
-  Height {round(height)}
-  RCT 0
-  """
+Upsample {args.upsample}
+Width {round(width)}
+Height {round(height)}
+RCT 0
+"""
 
   scale_x = width / viewBox[2]
   scale_y = height / viewBox[3]
@@ -341,8 +341,8 @@ def main():
             cubic_points.pop(0)
 
           current_spline.extend(cubic_points)
-        elif args.verbose:
-          print("Ignored segment: " + str(type(segment)))
+        elif type(segment) == Arc:
+          path.extend(segment.as_cubic_curves(curves=2))
 
       if current_spline:
         spline = create_spline(current_spline, args, color)

--- a/svg2jxl/svg2jxl.py
+++ b/svg2jxl/svg2jxl.py
@@ -131,9 +131,9 @@ def create_spline(points, args, color, thickness):
 
   bitdepth = args.bitdepth
 
-  if args.sharpness and thickness > 0.5:
-    thickness -= 0.25
-    bitdepth += 1
+  if args.sharpness > 0 and thickness > 0.5:
+    thickness -= args.sharpness / 4
+    bitdepth += args.sharpness
 
   new_color = [
     round((c / 255 - 1) * (2**(bitdepth - 1) - 1)) * sat for c in color
@@ -201,7 +201,7 @@ def main():
                       "--sharpness",
                       type=int,
                       default=1,
-                      help="Add sharpness to thick lines (default: 1)")
+                      help="Sharpness for thicker lines (default: 1)")
   parser.add_argument("-v",
                       "--verbose",
                       action="store_true",

--- a/svg2jxl/svg2jxl.py
+++ b/svg2jxl/svg2jxl.py
@@ -100,7 +100,7 @@ def sample_line(p0, p1):
   return points or [p0, p1]
 
 
-def create_spline(points, args, color):
+def create_spline(points, args, color, thickness):
   if len(points) > 2:
     old_len = len(points)
     points = optimize.optimize(points, args.error * (args.scale**2))
@@ -123,14 +123,20 @@ def create_spline(points, args, color):
              1] = [points[i][0] + direction[0], points[i][1] + direction[1]]
 
   if color[0] != color[1] or color[0] != color[2]:
-    thickness = args.thicknessc
+    thickness *= args.thicknessc
     sat = args.saturationc
   else:
-    thickness = args.thickness
+    thickness *= args.thickness
     sat = args.saturation
 
+  bitdepth = args.bitdepth
+
+  if args.sharpness and thickness > 0.5:
+    thickness -= 0.25
+    bitdepth += 1
+
   new_color = [
-    round((c / 255 - 1) * (2**(args.bitdepth - 1) - 1)) * sat for c in color
+    round((c / 255 - 1) * (2**(bitdepth - 1) - 1)) * sat for c in color
   ]
 
   spline = [
@@ -174,27 +180,32 @@ def main():
   parser.add_argument("-t",
                       "--thickness",
                       type=float,
-                      default=0.5,
-                      help="thickness for black lines (default: 0.5)")
+                      default=0.25,
+                      help="Thickness for black lines (default: 0.25)")
   parser.add_argument("-tc",
                       "--thicknessc",
                       type=float,
-                      default=0.5,
-                      help="thickness for colored lines (default: 0.5)")
+                      default=0.25,
+                      help="Thickness for colored lines (default: 0.25)")
   parser.add_argument("-sat",
                       "--saturation",
                       type=float,
                       default=1,
-                      help="saturation for black lines (default: 1)")
+                      help="Saturation for black lines (default: 1)")
   parser.add_argument("-satc",
                       "--saturationc",
                       type=float,
                       default=1,
-                      help="saturation for colored lines (default: 1)")
+                      help="Saturation for colored lines (default: 1)")
+  parser.add_argument("-sh",
+                      "--sharpness",
+                      type=int,
+                      default=1,
+                      help="Add sharpness to thick lines (default: 1)")
   parser.add_argument("-v",
                       "--verbose",
                       action="store_true",
-                      help="print more information to stdout")
+                      help="Print more information to stdout")
 
   args = parser.parse_args()
 
@@ -239,6 +250,7 @@ RCT 0
 
     for path, attribute in zip(paths, attributes):
       color = "#000000"
+      thickness = 1
       # Currently does not support classes (url(#id))
 
       if "fill" in attribute:
@@ -263,6 +275,9 @@ RCT 0
 
       if "fill-opacity" in attribute:
         if float(attribute["fill-opacity"]) == 0: continue
+
+      if "stroke-width" in attribute:
+        thickness = float(attribute["stroke-width"])
 
       current_spline = []
       for segment in path:
@@ -294,7 +309,7 @@ RCT 0
               cubic_points.reverse()
 
             if dist(current_spline[-1], cubic_points[0]) > 1:
-              spline = create_spline(current_spline, args, color)
+              spline = create_spline(current_spline, args, color, thickness)
               if spline:
                 spline_str = "\n".join(spline)
                 if spline_str not in splines:
@@ -327,7 +342,7 @@ RCT 0
               cubic_points.reverse()
 
             if dist(current_spline[-1], cubic_points[0]) > 1:
-              spline = create_spline(current_spline, args, color)
+              spline = create_spline(current_spline, args, color, thickness)
               if spline:
                 spline_str = "\n".join(spline)
                 if spline_str not in splines:
@@ -345,7 +360,7 @@ RCT 0
           path.extend(segment.as_cubic_curves(curves=2))
 
       if current_spline:
-        spline = create_spline(current_spline, args, color)
+        spline = create_spline(current_spline, args, color, thickness)
         if spline:
           spline_str = "\n".join(spline)
           if spline_str not in splines:


### PR DESCRIPTION
I made these modifications:
1. Add support for `stroke-width` property defining lines thickness,
2. Add some sharpness for thicker splines (>0.5px) by using color clamping, you can disable it by setting `-sh 0`,
3. Change default thickness to 0.25px so it better resembles original SVG.

See the sample files: [cubic.svg](https://user-images.githubusercontent.com/384997/164740028-64f3b2a2-0634-4eba-81f6-7c6e4141fefb.svg) and [cubic.jxl.zip](https://github.com/wwww-wwww/spline/files/8541964/cubic.jxl.zip) with sharpen and unsharpen JXL images.
 