### PR TITLE
use width and height as fallback for missing viewBox

### DIFF
--- a/svg2jxl/svg2jxl.py
+++ b/svg2jxl/svg2jxl.py
@@ -214,12 +214,12 @@ def main():
   tree = xml.etree.ElementTree.parse(args.input)
   root = tree.getroot()
 
-  viewBox = [0,0,0,0]
+  viewBox = [0, 0, 0, 0]
 
   try:
     viewBox = [float(x) for x in root.attrib["viewBox"].split(" ")]
   except:
-    viewBox = [0,0,float(root.attrib["width"]),float(root.attrib["height"])]
+    viewBox = [0, 0, float(root.attrib["width"]), float(root.attrib["height"])]
 
   off_x = -viewBox[0]
   off_y = -viewBox[1]

--- a/svg2jxl/svg2jxl.py
+++ b/svg2jxl/svg2jxl.py
@@ -214,7 +214,12 @@ def main():
   tree = xml.etree.ElementTree.parse(args.input)
   root = tree.getroot()
 
-  viewBox = [float(x) for x in root.attrib["viewBox"].split(" ")]
+  viewBox = [0,0,0,0]
+
+  try:
+    viewBox = [float(x) for x in root.attrib["viewBox"].split(" ")]
+  except:
+    viewBox = [0,0,float(root.attrib["width"]),float(root.attrib["height"])]
 
   off_x = -viewBox[0]
   off_y = -viewBox[1]


### PR DESCRIPTION
SVG parsing is hairy.

Running the script on various SVGs, a missing viewBox attribute seems to be the most common thing to go wrong.

This change makes the script fall back to the width and height attributes if the viewBox is missing, setting the offsets to 0.